### PR TITLE
Remove duplicate BatWiki-Background line

### DIFF
--- a/site/content/page/guilds/erelig/_index.md
+++ b/site/content/page/guilds/erelig/_index.md
@@ -20,8 +20,6 @@ Links:
 - [BatWiki - Evil Religious Background][BatWiki-Background]
 - [To Navigation](#navigation)
 
-[BatWiki-Background]: https://taikajuoma.ovh/wiki/Evil_religious
-
 ## Disciple
 
 Full name: The Disciples of Chaos - Short name: Disciples - Levels: 10


### PR DESCRIPTION
Removes the duplicate "BatWiki-Background" link.